### PR TITLE
Make entropy-region APIs universe polymorphic

### DIFF
--- a/ZhangYeung/EntropyRegion.lean
+++ b/ZhangYeung/EntropyRegion.lean
@@ -66,17 +66,17 @@ noncomputable abbrev entropyFn
 def shannonRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
   {F | shannonCone_n F}
 
-/-- The entropic region `Γ_n^*`, packaged as the set of actual entropy functions of `n` discrete random variables. The quantified probability space and codomain family are pinned to `Type` to keep the carrier in `Type`. -/
+/-- The entropic region `Γ_n^*`, packaged as the set of actual entropy functions of `n` discrete random variables. The quantified probability space and codomain family range over the ambient universe `u`, so a `Type u` realization is literally a member of the set. -/
 def entropyRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
-  {F | ∃ (Ω : Type) (_ : MeasurableSpace Ω) (μ : Measure Ω) (_ : IsProbabilityMeasure μ)
-      (S : Fin n → Type) (_ : ∀ i, MeasurableSpace (S i)) (_ : ∀ i, Fintype (S i))
+  {F | ∃ (Ω : Type u) (_ : MeasurableSpace Ω) (μ : Measure Ω) (_ : IsProbabilityMeasure μ)
+      (S : Fin n → Type u) (_ : ∀ i, MeasurableSpace (S i)) (_ : ∀ i, Fintype (S i))
       (_ : ∀ i, MeasurableSingletonClass (S i))
       (X : ∀ i : Fin n, Ω → S i),
       (∀ i, Measurable (X i)) ∧ F = entropyFn_n X μ}
 
 /-- The almost-entropic region `closure (Γ_n^*)`. -/
 def almostEntropicRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
-  closure (entropyRegion_n n)
+  closure (entropyRegion_n.{u} n)
 
 /-- Restrict a set function on `Fin n` to its first four coordinates. -/
 def restrictFirstFour {n : ℕ} (hn : 4 ≤ n) :
@@ -122,8 +122,8 @@ theorem entropyFn_n_restrictFirstFour
 /-- Entropic points remain entropic after restriction to the first four coordinates. -/
 theorem restrictFirstFour_mem_entropyRegion_n
     {n : ℕ} (hn : 4 ≤ n) {F : Finset (Fin n) → ℝ}
-    (hF : F ∈ entropyRegion_n n) :
-    restrictFirstFour hn F ∈ entropyRegion_n 4 := by
+    (hF : F ∈ entropyRegion_n.{u} n) :
+    restrictFirstFour hn F ∈ entropyRegion_n.{u} 4 := by
   rcases hF with ⟨Ω, hΩ, μ, hμ, S, hS, hFin, hMSC, X, hX, rfl⟩
   letI : MeasurableSpace Ω := hΩ
   letI : IsProbabilityMeasure μ := hμ
@@ -139,9 +139,9 @@ theorem restrictFirstFour_mem_entropyRegion_n
 /-- Almost-entropic points remain almost entropic after restriction to the first four coordinates. -/
 theorem restrictFirstFour_mem_almostEntropicRegion_n
     {n : ℕ} (hn : 4 ≤ n) {F : Finset (Fin n) → ℝ}
-    (hF : F ∈ almostEntropicRegion_n n) :
-    restrictFirstFour hn F ∈ almostEntropicRegion_n 4 := by
-  have h_map : Set.MapsTo (restrictFirstFour hn) (entropyRegion_n n) (entropyRegion_n 4) :=
+    (hF : F ∈ almostEntropicRegion_n.{u} n) :
+    restrictFirstFour hn F ∈ almostEntropicRegion_n.{u} 4 := by
+  have h_map : Set.MapsTo (restrictFirstFour hn) (entropyRegion_n.{u} n) (entropyRegion_n.{u} 4) :=
     fun _ h_mem => restrictFirstFour_mem_entropyRegion_n hn h_mem
   simpa [almostEntropicRegion_n] using h_map.closure (restrictFirstFour_continuous hn) hF
 

--- a/ZhangYeung/EntropyRegion.lean
+++ b/ZhangYeung/EntropyRegion.lean
@@ -74,7 +74,7 @@ def entropyRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
       (X : ∀ i : Fin n, Ω → S i),
       (∀ i, Measurable (X i)) ∧ F = entropyFn_n X μ}
 
-/-- The almost-entropic region `closure (Γ_n^*)`. -/
+/-- The almost-entropic region `closure (Γ_n^*)`. Inherits the universe parameter from `entropyRegion_n`: the closure is taken in the same ambient universe `u`, so a point witnessed by a `Type u` entropy function (or a limit of such) is literally a member of the set. -/
 def almostEntropicRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
   closure (entropyRegion_n.{u} n)
 

--- a/ZhangYeung/Theorem4.lean
+++ b/ZhangYeung/Theorem4.lean
@@ -749,7 +749,7 @@ private lemma not_mem_almostEntropicRegion_witness : F_witness ∉ almostEntropi
   intro hF
   exact not_zhangYeungHolds_witness (almostEntropicRegion_four_subset_zhangYeungRegion_4 hF)
 
-/-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** at `n = 4`. The Shannon outer bound `Γ_4` strictly contains the closure of the entropic region: there exists a set function in `Γ_4` that is not almost entropic. -/
+/-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** at `n = 4`. The Shannon outer bound `Γ_4` strictly contains the closure of the entropic region: there exists a set function in `Γ_4` that is not almost entropic. The non-membership claim is universe-polymorphic: for every universe `u`, `F_witness ∉ almostEntropicRegion_n.{u} 4`, since the closedness argument in `zhangYeungRegion_4` lives entirely at the level of `Finset (Fin 4) → ℝ`. -/
 theorem theorem4 :
     ∃ F : Finset (Fin 4) → ℝ, F ∈ shannonRegion_n 4 ∧ F ∉ almostEntropicRegion_n.{u} 4 := by
   refine ⟨F_witness, ?_, not_mem_almostEntropicRegion_witness⟩
@@ -839,7 +839,7 @@ theorem shannon_incomplete_ge_four (n : ℕ) (hn : 4 ≤ n) :
     ∃ F : Finset (Fin n) → ℝ, shannonCone_n F ∧ ¬ zhangYeungHolds_n F :=
   ⟨F_witness_n hn, shannonCone_of_witness_n hn, not_zhangYeungHolds_witness_n hn⟩
 
-/-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** for all `n ≥ 4`. The Shannon outer bound `Γ_n` strictly contains the closure of the entropic region: there exists a set function in `Γ_n` that is not almost entropic. -/
+/-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** for all `n ≥ 4`. The Shannon outer bound `Γ_n` strictly contains the closure of the entropic region: there exists a set function in `Γ_n` that is not almost entropic. The non-membership claim is universe-polymorphic: for every universe `u`, `F_witness_n hn ∉ almostEntropicRegion_n.{u} n`, by restricting any hypothetical almost-entropic realization back down to the first four coordinates and applying the `n = 4` exclusion. -/
 theorem theorem4_ge_four (n : ℕ) (hn : 4 ≤ n) :
     ∃ F : Finset (Fin n) → ℝ, F ∈ shannonRegion_n n ∧ F ∉ almostEntropicRegion_n.{u} n := by
   refine ⟨F_witness_n hn, ?_, ?_⟩

--- a/ZhangYeung/Theorem4.lean
+++ b/ZhangYeung/Theorem4.lean
@@ -727,7 +727,7 @@ private lemma isClosed_zhangYeungRegion_4 : IsClosed zhangYeungRegion_4 := by
 
 /-- Every entropic point in dimension `4` lies in the closed Zhang-Yeung region. -/
 private lemma entropyRegion_four_subset_zhangYeungRegion_4 :
-    entropyRegion_n 4 ⊆ zhangYeungRegion_4 := by
+    entropyRegion_n.{u} 4 ⊆ zhangYeungRegion_4 := by
   intro F hF
   rcases hF with ⟨Ω, hΩ, μ, hμ, S, hS, hFin, hMSC, X, hX, h_eq⟩
   letI : MeasurableSpace Ω := hΩ
@@ -740,18 +740,18 @@ private lemma entropyRegion_four_subset_zhangYeungRegion_4 :
 
 /-- Every almost-entropic point in dimension `4` lies in the Zhang-Yeung region. -/
 private lemma almostEntropicRegion_four_subset_zhangYeungRegion_4 :
-    almostEntropicRegion_n 4 ⊆ zhangYeungRegion_4 := by
+    almostEntropicRegion_n.{u} 4 ⊆ zhangYeungRegion_4 := by
   simpa [almostEntropicRegion_n] using
     (closure_minimal entropyRegion_four_subset_zhangYeungRegion_4 isClosed_zhangYeungRegion_4)
 
 /-- The witness is not almost entropic in dimension `4`. -/
-private lemma not_mem_almostEntropicRegion_witness : F_witness ∉ almostEntropicRegion_n 4 := by
+private lemma not_mem_almostEntropicRegion_witness : F_witness ∉ almostEntropicRegion_n.{u} 4 := by
   intro hF
   exact not_zhangYeungHolds_witness (almostEntropicRegion_four_subset_zhangYeungRegion_4 hF)
 
 /-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** at `n = 4`. The Shannon outer bound `Γ_4` strictly contains the closure of the entropic region: there exists a set function in `Γ_4` that is not almost entropic. -/
 theorem theorem4 :
-    ∃ F : Finset (Fin 4) → ℝ, F ∈ shannonRegion_n 4 ∧ F ∉ almostEntropicRegion_n 4 := by
+    ∃ F : Finset (Fin 4) → ℝ, F ∈ shannonRegion_n 4 ∧ F ∉ almostEntropicRegion_n.{u} 4 := by
   refine ⟨F_witness, ?_, not_mem_almostEntropicRegion_witness⟩
   change shannonCone_n F_witness
   simpa using shannonCone_of_witness
@@ -841,12 +841,12 @@ theorem shannon_incomplete_ge_four (n : ℕ) (hn : 4 ≤ n) :
 
 /-- **Theorem 4 of [@zhangyeung1998, §II, eq. 26]** for all `n ≥ 4`. The Shannon outer bound `Γ_n` strictly contains the closure of the entropic region: there exists a set function in `Γ_n` that is not almost entropic. -/
 theorem theorem4_ge_four (n : ℕ) (hn : 4 ≤ n) :
-    ∃ F : Finset (Fin n) → ℝ, F ∈ shannonRegion_n n ∧ F ∉ almostEntropicRegion_n n := by
+    ∃ F : Finset (Fin n) → ℝ, F ∈ shannonRegion_n n ∧ F ∉ almostEntropicRegion_n.{u} n := by
   refine ⟨F_witness_n hn, ?_, ?_⟩
   · change shannonCone_n (F_witness_n hn)
     exact shannonCone_of_witness_n hn
   · intro hF
-    have h_restrict : F_witness ∈ almostEntropicRegion_n 4 := by
+    have h_restrict : F_witness ∈ almostEntropicRegion_n.{u} 4 := by
       simpa [restrictFirstFour_witness_n hn] using restrictFirstFour_mem_almostEntropicRegion_n hn hF
     exact not_mem_almostEntropicRegion_witness h_restrict
 

--- a/ZhangYeungTest/EntropyRegion.lean
+++ b/ZhangYeungTest/EntropyRegion.lean
@@ -34,11 +34,21 @@ example (n : ℕ) : shannonRegion_n n = {F | shannonCone_n F} :=
   rfl
 
 example (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
-  entropyRegion_n n
+  entropyRegion_n.{u} n
 
 example (n : ℕ) :
-    almostEntropicRegion_n n = closure (entropyRegion_n n) :=
+    almostEntropicRegion_n.{u} n = closure (entropyRegion_n.{u} n) :=
   rfl
+
+example
+    {Ω : Type u} [MeasurableSpace Ω]
+    {n : ℕ} {S : Fin n → Type u}
+    [∀ i, MeasurableSpace (S i)] [∀ i, Fintype (S i)]
+    [∀ i, MeasurableSingletonClass (S i)]
+    (X : ∀ i : Fin n, Ω → S i) (hX : ∀ i, Measurable (X i))
+    (μ : Measure Ω) [IsProbabilityMeasure μ] :
+    entropyFn_n X μ ∈ entropyRegion_n.{u} n := by
+  exact ⟨Ω, inferInstance, μ, inferInstance, S, inferInstance, inferInstance, inferInstance, X, hX, rfl⟩
 
 example {n : ℕ} (hn : 4 ≤ n) :
     restrictFirstFour hn = fun F α => F (α.map (Fin.castLEEmb hn)) :=

--- a/ZhangYeungTest/Theorem4.lean
+++ b/ZhangYeungTest/Theorem4.lean
@@ -104,8 +104,8 @@ example :
 
 example :
     ∃ F : Finset (Fin 4) → ℝ,
-      F ∈ shannonRegion_n 4 ∧ F ∉ almostEntropicRegion_n 4 :=
-  theorem4
+      F ∈ shannonRegion_n 4 ∧ F ∉ almostEntropicRegion_n.{u} 4 :=
+  theorem4.{u}
 
 end MainStatements
 
@@ -198,8 +198,8 @@ example (n : ℕ) (hn : 4 ≤ n) :
 closure separation. -/
 example (n : ℕ) (hn : 4 ≤ n) :
     ∃ F : Finset (Fin n) → ℝ,
-      F ∈ shannonRegion_n n ∧ F ∉ almostEntropicRegion_n n :=
-  theorem4_ge_four n hn
+      F ∈ shannonRegion_n n ∧ F ∉ almostEntropicRegion_n.{u} n :=
+  theorem4_ge_four.{u} n hn
 
 /- Pinned signature: `F_witness_n` is the lifted witness. -/
 example {n : ℕ} (hn : 4 ≤ n) : shannonCone_n (F_witness_n hn) :=

--- a/docs/plans/done/2026-04-19-exact-theorem-4-entropic-region-closure.md
+++ b/docs/plans/done/2026-04-19-exact-theorem-4-entropic-region-closure.md
@@ -88,7 +88,7 @@ def entropyRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
 
 This is the first point where the repository will literally name `Γ_n^*` rather than reasoning around it.
 
-**Universe discipline.** Quantifying existentially over `(Ω : Type u)` and `(S : Fin n → Type u)` inside a `Set (Finset (Fin n) → ℝ)` raises a predicativity concern: the carrier lives in `Type`, so the existential cannot range over an arbitrary universe without an explicit universe parameter on `entropyRegion_n` itself. Pin `Ω` and each `S i` to `Type` (i.e., universe 0) in the definition. This matches how PFR's entropy API is typically instantiated in this repo -- the random-variable families in `Theorem4.lean` already live in a fixed universe -- so the restriction does not cost anything the paper-level theorem actually needs. If a downstream consumer later requires `Type u`-parameterized regions, introduce a polymorphic variant then; do not carry one up front.
+**Universe discipline.** The initial M4.5 landing pinned the `entropyRegion_n` existential to `Type` (universe 0) out of caution about predicativity. That restriction was later removed by the follow-up plan `2026-04-20-entropy-region-universe-polymorphism.md`: `entropyRegion_n` and `almostEntropicRegion_n` now quantify over the ambient universe `u`, so a `Type u` entropy realization is literally a member of the named region sets. The exact theorem layer (`theorem4`, `theorem4_ge_four`) remains unchanged except for inheriting that polymorphic surface.
 
 ### 3. Prove the exact `n = 4` theorem through a closed-cone argument
 
@@ -262,9 +262,9 @@ Mitigation: keep `entropyFn_n` definitionally identical to the current `entropyF
 
 ### 4. Universe polymorphism of `entropyRegion_n`
 
-The entropic region quantifies existentially over a probability space `Ω` and a codomain family `S : Fin n → Type`. Ranging that existential over an arbitrary universe breaks predicativity relative to the carrier `Set (Finset (Fin n) → ℝ)`, which lives in `Type`.
+This risk did materialize as an API follow-up rather than as a blocker for the exact theorem itself: the initial `Type`-pinned region surface left `theorem4_finite` more polymorphic than membership in `entropyRegion_n` and `almostEntropicRegion_n`.
 
-Mitigation: pin both `Ω` and each `S i` to `Type` (universe 0) in the definition of `entropyRegion_n`, per Design §2. A universe-parameterized variant can land later if a downstream consumer demands it; do not introduce one up front.
+Resolution: the follow-up plan `2026-04-20-entropy-region-universe-polymorphism.md` generalized `entropyRegion_n` and `almostEntropicRegion_n` to the ambient universe `u`, and the surrounding transport lemmas and exact-theorem statements were updated to use that shared universe explicitly.
 
 ## Verification
 

--- a/docs/plans/done/2026-04-20-entropy-region-universe-polymorphism.md
+++ b/docs/plans/done/2026-04-20-entropy-region-universe-polymorphism.md
@@ -1,15 +1,15 @@
 ---
 title: "Universe-polymorphic `entropyRegion_n` for exact Theorem 4"
 created: 2026-04-20
-status: proposed
-branch: TBD
+status: done
+branch: refactor/entropy-region-universe-polymorphism
 roadmap: docs/plans/todo/2026-04-15-zhang-yeung-formalization-roadmap.md
 depends_on: M4 / M4.5 (`ZhangYeung/EntropyRegion.lean`, `ZhangYeung/Theorem4.lean`) -- in particular `entropyRegion_n`, `almostEntropicRegion_n`, `restrictFirstFour`, `zhangYeungHolds_of_entropy`, `theorem4`, and `theorem4_ge_four`.
 ---
 
 ## Status
 
-Proposed. Follow-up to the M4.5 exact-closure work that landed on `formalize/m4-theorem-4` (PR #11). Suggested by a Copilot PR review on `ZhangYeung/EntropyRegion.lean:68`. With the Finite/Fintype alignment (`docs/plans/done/2026-04-21-finite-fintype-pfr-alignment-and-native-decide-removal.md`) and the structural-submodularity proof (`docs/plans/done/2026-04-21-theorem4-structural-submodularity-proof.md`) now complete, this is the last open follow-up on the M4 / M4.5 track.
+Done. Route 1 landed. `entropyRegion_n` now quantifies over `(Ω : Type u)` and `(S : Fin n → Type u)`, `almostEntropicRegion_n` closes over that same universe-polymorphic surface, and the immediate consumers (`restrictFirstFour_mem_entropyRegion_n`, `restrictFirstFour_mem_almostEntropicRegion_n`, `theorem4`, `theorem4_ge_four`) now thread the shared universe explicitly. The Lean API tests also pin the direct-membership use case `entropyFn_n X μ ∈ entropyRegion_n.{u} n`, so a `Type u` entropy realization is literally a member of the public region set.
 
 ## Context
 

--- a/docs/plans/todo/2026-04-20-entropy-region-universe-polymorphism.md
+++ b/docs/plans/todo/2026-04-20-entropy-region-universe-polymorphism.md
@@ -9,7 +9,7 @@ depends_on: M4 / M4.5 (`ZhangYeung/EntropyRegion.lean`, `ZhangYeung/Theorem4.lea
 
 ## Status
 
-Proposed. Follow-up to the M4.5 exact-closure work that landed on `formalize/m4-theorem-4` (PR #11). Suggested by a Copilot PR review on `ZhangYeung/EntropyRegion.lean:68`.
+Proposed. Follow-up to the M4.5 exact-closure work that landed on `formalize/m4-theorem-4` (PR #11). Suggested by a Copilot PR review on `ZhangYeung/EntropyRegion.lean:68`. With the Finite/Fintype alignment (`docs/plans/done/2026-04-21-finite-fintype-pfr-alignment-and-native-decide-removal.md`) and the structural-submodularity proof (`docs/plans/done/2026-04-21-theorem4-structural-submodularity-proof.md`) now complete, this is the last open follow-up on the M4 / M4.5 track.
 
 ## Context
 
@@ -34,13 +34,11 @@ Mathematically this is harmless for the paper-level theorem: every finite-codoma
 
 Offer a universe-polymorphic entropic-region surface without breaking existing Lean API users.
 
-Two routes, roughly in order of preference:
+The primary approach is route 1: parameterize `entropyRegion_n` by a universe so that a `Type u` entropy function is *literally* a member of the set. Route 2 is a fallback to keep in reserve only if route 1 produces opaque universe-unification failures without an isolable cause; it does not fully close the gap at the set-membership level (see below).
 
-1. **Parameterize `entropyRegion_n` by a universe.** Introduce `universe u` in `ZhangYeung/EntropyRegion.lean` and restate `entropyRegion_n` with `(Ω : Type u)` and `(S : Fin n → Type u)`. The carrier `Set (Finset (Fin n) → ℝ)` stays in `Type 0`; only the existential ranges over `Type u`. Current callers default to `u = 0` and are unaffected. Downstream users instantiate with whichever universe fits.
+1. **Parameterize `entropyRegion_n` by a universe (primary).** Consume the `universe u` already declared in `ZhangYeung/EntropyRegion.lean` and restate `entropyRegion_n` with `(Ω : Type u)` and `(S : Fin n → Type u)`. The carrier `Set (Finset (Fin n) → ℝ)` stays in `Type 0`; only the existential ranges over `Type u`. Current callers default to `u = 0` and are unaffected. Downstream users instantiate with whichever universe fits. After this lands, a user with a `Type u` entropy function can directly write `F ∈ entropyRegion_n n` without any manual detour.
 
-2. **Keep the `Type 0` region; add a transport lemma.** If universe polymorphism bleeds awkwardly through `almostEntropicRegion_n`, `restrictFirstFour_mem_entropyRegion_n`, and `restrictFirstFour_mem_almostEntropicRegion_n`, retain the current definitions and publish a public lemma of the form "any finite-codomain entropy function over `Type u` is already realized by a `Type 0` entropy function." Callers then transport explicitly.
-
-Prefer route 1 if the surrounding lemmas accept a `universe u` parameter cleanly; fall back to route 2 if not.
+2. **Keep the `Type 0` region; add a transport lemma (fallback only).** If universe polymorphism bleeds awkwardly through `almostEntropicRegion_n`, `restrictFirstFour_mem_entropyRegion_n`, and `restrictFirstFour_mem_almostEntropicRegion_n`, retain the current definitions and publish a public lemma of the form "any finite-codomain entropy function over `Type u` is already realized by a `Type 0` entropy function." Callers then transport explicitly. This is strictly weaker than route 1: a user with a `Type u` entropy function still cannot write `F ∈ entropyRegion_n n` literally, only invoke the lemma to obtain a witness equality with some `Type 0` entropy function. Route 2 closes the gap at the theorem level (every `Type u` realization has a `Type 0` equal) but not at the set-membership level, so adopt it only if route 1 is blocked.
 
 ## Non-goals
 
@@ -52,10 +50,10 @@ Prefer route 1 if the surrounding lemmas accept a `universe u` parameter cleanly
 
 ### Route 1: universe parameter on `entropyRegion_n`
 
-Add `universe u` at the top of `ZhangYeung/EntropyRegion.lean` (it may already be there for `entropyFn_n`). Rewrite `entropyRegion_n` as:
+`ZhangYeung/EntropyRegion.lean` already declares `universe u` for `entropyFn_n` and `entropyFn_n_restrictFirstFour`, so no new declaration is needed — route 1 simply consumes the ambient `universe u`. Rewrite `entropyRegion_n` as:
 
 ```lean
-def entropyRegion_n.{u} (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
+def entropyRegion_n (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
   {F | ∃ (Ω : Type u) (_ : MeasurableSpace Ω) (μ : Measure Ω) (_ : IsProbabilityMeasure μ)
       (S : Fin n → Type u) (_ : ∀ i, MeasurableSpace (S i)) (_ : ∀ i, Fintype (S i))
       (_ : ∀ i, MeasurableSingletonClass (S i))
@@ -63,12 +61,16 @@ def entropyRegion_n.{u} (n : ℕ) : Set (Finset (Fin n) → ℝ) :=
       (∀ i, Measurable (X i)) ∧ F = entropyFn_n X μ}
 ```
 
+Match the local style: plain `def` with the ambient `universe u`, not an explicit `def entropyRegion_n.{u}` head. The sibling `entropyFn_n` already uses this form and the test module pins it that way.
+
 Every downstream consumer (`restrictFirstFour_mem_entropyRegion_n`, `almostEntropicRegion_n`, `theorem4`, `theorem4_ge_four`) either becomes universe-polymorphic in the same variable or fixes `u := 0` explicitly when that is the intended scope.
 
 Key decisions:
 
 - Does `almostEntropicRegion_n` take the universe parameter as well? Likely yes: it is literally `closure (entropyRegion_n n)` and its closure argument does not care about `u`.
 - Does `theorem4` fix `u := 0` or stay polymorphic? If universe-polymorphic, its `F_witness` non-membership claim becomes "for every universe `u`, `F_witness ∉ almostEntropicRegion_n.{u} 4`"; proving that is still a one-liner through `zhangYeungRegion_4`'s closedness because the closedness argument lives entirely at the level of `Finset (Fin 4) → ℝ`.
+- **Retain `Fintype` inside the existential, not `Finite`.** The completed Finite/Fintype alignment plan (`docs/plans/done/2026-04-21-finite-fintype-pfr-alignment-and-native-decide-removal.md`) deliberately kept `Fintype (S i)` and `MeasurableSingletonClass (S i)` inside this existential body while converting ambient typeclass arguments elsewhere in the module from `[Fintype ...]` to `[Finite ...]`. Universe polymorphism is orthogonal to the finiteness layer; do not change either `Fintype` or `MeasurableSingletonClass` here.
+- **Single-universe convention, matching `theorem4_finite`.** The current `theorem4_finite` binds both `Ω` and each `S i` at a single universe `u` rather than splitting into `u` and `v`. Inherit that convention in route 1: a single universe parameter for both. Splitting would double the sweep without matching any existing call site.
 
 ### Route 2: transport lemma
 
@@ -88,7 +90,7 @@ The proof uses the `Fintype (S i)`-to-`Fin (Fintype.card (S i))` equivalence and
 
 ## Risks
 
-1. **Cascading universe parameters.** Adding `universe u` to `entropyRegion_n` forces surrounding lemmas to either lift or pin. If the downstream surface is small (it currently is: just `restrictFirstFour_mem_entropyRegion_n`, `restrictFirstFour_mem_almostEntropicRegion_n`, and the three exact-theorem statements), the sweep is bounded.
+1. **Cascading universe parameters.** Adding `universe u` to `entropyRegion_n` forces surrounding lemmas to either lift or pin. The downstream surface is small but broader than the public API alone: `restrictFirstFour_mem_entropyRegion_n` and `restrictFirstFour_mem_almostEntropicRegion_n` in `ZhangYeung/EntropyRegion.lean`; the three exact-theorem statements (`theorem4_finite`, `theorem4`, `theorem4_ge_four`); and three `private` lemmas in `ZhangYeung/Theorem4.lean` that destructure the `entropyRegion_n` existential directly: `entropyRegion_four_subset_zhangYeungRegion_4`, `almostEntropicRegion_four_subset_zhangYeungRegion_4`, and `not_mem_almostEntropicRegion_witness`. Each destructure still compiles after the universe is threaded through, but the pattern matches must be updated. The sweep is bounded but not limited to the public surface.
 2. **Test-module breakage.** `ZhangYeungTest/EntropyRegion.lean` and `ZhangYeungTest/Theorem4.lean` pin signatures; a universe parameter shows up as an implicit and may need to be annotated. Budget time to refresh the pins.
 3. **Elaboration cost.** Pinning `u := 0` at every call site is cheap, but diagnosing universe errors in downstream proofs takes learned practice. Prefer route 2 if the first attempt at route 1 produces opaque universe-unification failures.
 

--- a/docs/reviews/2026-04-22-refactor-entropy-region-universe-polymorphism.md
+++ b/docs/reviews/2026-04-22-refactor-entropy-region-universe-polymorphism.md
@@ -1,0 +1,106 @@
+## Branch Review: refactor/entropy-region-universe-polymorphism
+
+Base: main (merge base: 7b77858)
+Commits: 3
+Files changed: 6 (0 added, 6 modified, 0 deleted, 1 renamed)
+Reviewed through: c61a4c4
+
+### Summary
+
+This branch executes the follow-up plan `2026-04-20-entropy-region-universe-polymorphism.md`, generalizing `entropyRegion_n` and `almostEntropicRegion_n` from a `Type 0`-pinned existential to one that quantifies over the ambient `universe u` already declared in `ZhangYeung/EntropyRegion.lean`. The change is surgical: the definitions themselves, the two transport lemmas on that module, three private destructuring lemmas in `ZhangYeung/Theorem4.lean`, and both top-level exact-closure theorems (`theorem4`, `theorem4_ge_four`) now thread the same universe parameter. The test suite pins the new direct-membership surface (`entropyFn_n X μ ∈ entropyRegion_n.{u} n`), and both the originating M4.5 plan and the follow-up plan are updated to reflect the landed state.
+
+### Changes by Area
+
+**Entropy-region surface (`ZhangYeung/EntropyRegion.lean`)**
+Rewrites `entropyRegion_n` to bind `(Ω : Type u)` and `(S : Fin n → Type u)` via the module-level `universe u` declaration (no `.{u}` on the def head, matching the local style used by `entropyFn_n`). `almostEntropicRegion_n` explicitly forwards the universe with `closure (entropyRegion_n.{u} n)`. The two transport lemmas `restrictFirstFour_mem_entropyRegion_n` and `restrictFirstFour_mem_almostEntropicRegion_n` gain `.{u}` annotations on both their hypotheses and their conclusions so that the restriction is a same-universe map. `Fintype` and `MeasurableSingletonClass` are retained inside the existential as the plan directed.
+
+**Exact-theorem statements (`ZhangYeung/Theorem4.lean`)**
+Three private helpers (`entropyRegion_four_subset_zhangYeungRegion_4`, `almostEntropicRegion_four_subset_zhangYeungRegion_4`, `not_mem_almostEntropicRegion_witness`) thread `.{u}` through their statements. The two public exact theorems `theorem4` and `theorem4_ge_four` now express the non-membership claim against `almostEntropicRegion_n.{u}`, keeping them universe-polymorphic. No proof bodies change beyond the universe annotations (and the `.{u}` routing through `h_restrict` in `theorem4_ge_four`).
+
+**Tests (`ZhangYeungTest/EntropyRegion.lean`, `ZhangYeungTest/Theorem4.lean`)**
+Region-surface pins add `.{u}` where needed, and a new `example` under `section Regions` witnesses the core motivating consequence: a `Type u` entropy function is literally a member of `entropyRegion_n.{u} n`, constructed by `⟨Ω, inferInstance, μ, inferInstance, S, …, X, hX, rfl⟩`. The Theorem 4 test module pins both `theorem4.{u}` and `theorem4_ge_four.{u}` at the universe-annotated signatures.
+
+**Plan documentation (`docs/plans/...`)**
+The M4.5 plan `2026-04-19-exact-theorem-4-entropic-region-closure.md` has its Universe discipline paragraph (Design §2) and Risks §4 rewritten to point at the follow-up plan and record that the `Type 0` restriction has been lifted. The follow-up plan `2026-04-20-entropy-region-universe-polymorphism.md` moves from `docs/plans/todo/` to `docs/plans/done/` with `status: done` and `branch: refactor/entropy-region-universe-polymorphism`, plus a completed-state Status section.
+
+### File Inventory
+
+**Modified (5)**
+
+- `ZhangYeung/EntropyRegion.lean`
+- `ZhangYeung/Theorem4.lean`
+- `ZhangYeungTest/EntropyRegion.lean`
+- `ZhangYeungTest/Theorem4.lean`
+- `docs/plans/done/2026-04-19-exact-theorem-4-entropic-region-closure.md`
+
+**Renamed (1)**
+
+- `docs/plans/todo/2026-04-20-entropy-region-universe-polymorphism.md` → `docs/plans/done/2026-04-20-entropy-region-universe-polymorphism.md` (59% similarity; content also edited during the move to flip `status: proposed` → `status: done`, record the branch, rewrite Status and Goal to reflect the landed route-1 choice, add the "retain Fintype" and "single-universe convention" key decisions, expand Risks §1's downstream-surface enumeration, and note that `universe u` is already declared).
+
+### Notable Changes
+
+- **API-shape change on a public surface.** `entropyRegion_n`, `almostEntropicRegion_n`, `theorem4`, and `theorem4_ge_four` all gain an implicit universe parameter. Existing callers that left the universe free will still elaborate (Lean defaults them), but any caller that explicitly annotated `entropyRegion_n.{0}` previously did not exist; any new downstream code that *does* care about universes now has a literal set-membership path. No deprecation is needed, only documentation.
+- **No dependency, CI, or build-config changes.** Lake config, toolchain, and CI workflows are untouched.
+- **No new definitions or theorems.** Everything on the branch is either a universe annotation, a plan-doc edit, or one new `example` in the test module.
+
+### Plan Compliance
+
+**Compliance verdict: excellent.** The branch implements route 1 of the plan cleanly and exhaustively: every item the plan identified as part of the downstream sweep is updated, the key decisions the plan called out (retain `Fintype`, single-universe convention, plain `def` with ambient `universe u`) are all honored, and the exit criterion (a caller can write `F ∈ entropyRegion_n n` for a `Type u` entropy function without a manual `Type 0` detour) is pinned directly in the test module. No scope creep, no quality shortcuts, and both plan documents are kept in sync with the landed code.
+
+**Overall progress: 5/5 verification criteria met.**
+
+**Done items (route 1, from the plan's Design sketch and Key decisions):**
+
+1. `entropyRegion_n` consumes the ambient `universe u` and binds `(Ω : Type u)`, `(S : Fin n → Type u)`. Implemented verbatim (`EntropyRegion.lean:70-75`), matching the plan's code block including the `Fintype` retention inside the existential.
+2. `almostEntropicRegion_n` inherits the universe parameter, realized via the explicit `closure (entropyRegion_n.{u} n)` (`EntropyRegion.lean:79`). The plan's "likely yes" is resolved affirmatively.
+3. Both transport lemmas (`restrictFirstFour_mem_entropyRegion_n`, `restrictFirstFour_mem_almostEntropicRegion_n`) thread `.{u}` through hypotheses, conclusions, and intermediate `MapsTo` constructions (`EntropyRegion.lean:123-146`).
+4. All three private destructuring lemmas in `ZhangYeung/Theorem4.lean` (`entropyRegion_four_subset_zhangYeungRegion_4`, `almostEntropicRegion_four_subset_zhangYeungRegion_4`, `not_mem_almostEntropicRegion_witness`) are updated at lines 729-750. The Risks §1 enumeration called these out explicitly; every one is handled.
+5. `theorem4` and `theorem4_ge_four` state the non-membership claim against `almostEntropicRegion_n.{u}` (`Theorem4.lean:753-757, 843-851`). These are the public paper-level theorems, kept universe-polymorphic as the plan's Key decisions §2 suggested.
+6. Test-module pins refreshed: `ZhangYeungTest/EntropyRegion.lean:37,40,50,108` and `ZhangYeungTest/Theorem4.lean:107-108, 201-202`. The universe implicit is made explicit via `.{u}`, per Risk §2's warning.
+7. Direct-membership example added (`ZhangYeungTest/EntropyRegion.lean:43-51`): `entropyFn_n X μ ∈ entropyRegion_n.{u} n` for arbitrary `Ω : Type u` and `S : Fin n → Type u`. This is the literal artefact that the plan's Goal and Exit criteria called for — the thing a user could not previously write without a detour.
+8. The M4.5 plan's Universe-discipline section (`docs/plans/done/2026-04-19-exact-theorem-4-entropic-region-closure.md`, Design §2 and Risks §4) is rewritten to reflect the lifted restriction, satisfying Verification criterion 5.
+9. Plan moved from `todo/` to `done/` with `status: done` and the branch recorded.
+
+**Partially done items: none.**
+
+**Not started items: none.**
+
+**Deviations: none of substance.**
+
+- *Minor stylistic deviation.* The plan's Risks §2 warned that universe parameters "may need to be annotated" in test pins, suggesting the annotation would be a response to breakage. In the diff, `.{u}` is used consistently across test pins even where elaboration alone might have succeeded. This is strictly more explicit and avoids coupling the tests to Lean's universe defaulting, which I read as an improvement on what the plan literally asked for, not a regression.
+- *Cascading universe sweep was exactly the predicted surface.* Risks §1 in the plan enumerated nine declarations as the downstream blast radius. The diff touches precisely those nine (plus the test modules that pin them and the two plan docs), with no extra churn.
+
+**Fidelity concerns: none.**
+
+The implementation matches the plan's intent down to the stylistic choices — plain `def entropyRegion_n` with ambient `universe u` (not a `.{u}` head), single shared universe between `Ω` and `S` (matching `theorem4_finite`), and retained `Fintype`. The plan's Exit criterion names two alternative outcomes; the stronger one landed.
+
+### Code Quality Assessment
+
+**Overall quality: ready to merge.** The diff is small, focused, mechanical where it should be mechanical, and type-disciplined where it should be type-disciplined. It does exactly one thing and it does it cleanly.
+
+**Strengths:**
+
+- *Minimal surface touched.* Six files, no new definitions, one new `example`. Every line change is either a universe annotation or a plan-doc edit. That is the correct shape for a universe-polymorphism refactor and it minimizes review burden on downstream consumers.
+- *Universe parameter routed explicitly where it matters.* The transport lemmas (`restrictFirstFour_mem_entropyRegion_n`, `restrictFirstFour_mem_almostEntropicRegion_n`) write `entropyRegion_n.{u} n` on both sides of the `MapsTo`. This rules out a class of failure mode where Lean unifies the two sides at different universes and produces an inscrutable error downstream.
+- *Direct-membership test is exactly the right shape.* The new `example` at `ZhangYeungTest/EntropyRegion.lean:43-51` is the closest thing to a regression test for the stated goal: a `Type u` entropy function is now literally a member of the region set. It is proved by a single `⟨…⟩` with `inferInstance`, which is the cleanest possible witness that typeclass inference is intact and the membership is definitional.
+- *Private helpers in `Theorem4.lean` were not overlooked.* The plan flagged that the destructuring pattern matches had to be updated. They are, correctly; the `letI`-heavy preamble in `entropyRegion_four_subset_zhangYeungRegion_4` (`Theorem4.lean:732-737`) continues to work because the shared universe makes typeclass transport trivial.
+- *Documentation trail is good.* Both the originating M4.5 plan and the follow-up plan are updated in the same commit series. A future reader looking at either plan gets a consistent story; the M4.5 plan's Risks §4 "Resolution" paragraph even names the follow-up plan file.
+- *Docstring on `entropyRegion_n` is updated to describe the new behaviour.* The phrasing "a `Type u` realization is literally a member of the set" is the clearest possible framing of what changed.
+
+**Issues to address: none blocking.**
+
+**Suggestions (optional, non-blocking):**
+
+- *Docstring asymmetry on `almostEntropicRegion_n`.* The `entropyRegion_n` docstring was updated to mention the universe change, but `almostEntropicRegion_n`'s docstring (`EntropyRegion.lean:77`) still reads "The almost-entropic region `closure (Γ_n^*)`." A single line noting that the closure also ranges over the ambient `u` would match the symmetry the code already has. This is minor — the code itself is clear and the plan's Exit criterion does not call for it.
+- *No public-lemma commentary on the universe implicit in `theorem4`.* `theorem4`'s docstring (`Theorem4.lean:752`) is unchanged. A reader who notices `almostEntropicRegion_n.{u}` in the statement and wonders whether `theorem4` is universe-polymorphic or `u`-fixed has to read `Theorem4.lean`'s header. A one-line addition to the docstring ("the non-membership claim holds at every universe `u`") would close that gap. Again, minor.
+- *The explicit `theorem4.{u}` / `theorem4_ge_four.{u}` in the test module is belt-and-suspenders.* Since those theorems take their universe from the enclosing `universe u` at `ZhangYeungTest/EntropyRegion.lean:15` / `ZhangYeungTest/Theorem4.lean`, the `.{u}` annotation is explicit but not required. I read this as a deliberate defensive choice and would leave it; mentioning it only for completeness.
+
+**Completeness:**
+
+- No TODO, FIXME, HACK, or XXX comments introduced.
+- No placeholder or commented-out code.
+- New API surface (universe parameter on `entropyRegion_n`, `almostEntropicRegion_n`, `theorem4`, `theorem4_ge_four`) has a corresponding test example.
+- Documentation is updated.
+- No partial-implementation or half-migrated patterns visible.
+
+The branch is in a ready-to-merge state. No follow-up work is implied by the diff.

--- a/docs/reviews/2026-04-22-refactor-entropy-region-universe-polymorphism.md
+++ b/docs/reviews/2026-04-22-refactor-entropy-region-universe-polymorphism.md
@@ -25,7 +25,7 @@ The M4.5 plan `2026-04-19-exact-theorem-4-entropic-region-closure.md` has its Un
 
 ### File Inventory
 
-**Modified (5)**
+#### Modified (5)
 
 - `ZhangYeung/EntropyRegion.lean`
 - `ZhangYeung/Theorem4.lean`
@@ -33,7 +33,7 @@ The M4.5 plan `2026-04-19-exact-theorem-4-entropic-region-closure.md` has its Un
 - `ZhangYeungTest/Theorem4.lean`
 - `docs/plans/done/2026-04-19-exact-theorem-4-entropic-region-closure.md`
 
-**Renamed (1)**
+#### Renamed (1)
 
 - `docs/plans/todo/2026-04-20-entropy-region-universe-polymorphism.md` → `docs/plans/done/2026-04-20-entropy-region-universe-polymorphism.md` (59% similarity; content also edited during the move to flip `status: proposed` → `status: done`, record the branch, rewrite Status and Goal to reflect the landed route-1 choice, add the "retain Fintype" and "single-universe convention" key decisions, expand Risks §1's downstream-surface enumeration, and note that `universe u` is already declared).
 
@@ -85,7 +85,7 @@ The implementation matches the plan's intent down to the stylistic choices — p
 - *Direct-membership test is exactly the right shape.* The new `example` at `ZhangYeungTest/EntropyRegion.lean:43-51` is the closest thing to a regression test for the stated goal: a `Type u` entropy function is now literally a member of the region set. It is proved by a single `⟨…⟩` with `inferInstance`, which is the cleanest possible witness that typeclass inference is intact and the membership is definitional.
 - *Private helpers in `Theorem4.lean` were not overlooked.* The plan flagged that the destructuring pattern matches had to be updated. They are, correctly; the `letI`-heavy preamble in `entropyRegion_four_subset_zhangYeungRegion_4` (`Theorem4.lean:732-737`) continues to work because the shared universe makes typeclass transport trivial.
 - *Documentation trail is good.* Both the originating M4.5 plan and the follow-up plan are updated in the same commit series. A future reader looking at either plan gets a consistent story; the M4.5 plan's Risks §4 "Resolution" paragraph even names the follow-up plan file.
-- *Docstring on `entropyRegion_n` is updated to describe the new behaviour.* The phrasing "a `Type u` realization is literally a member of the set" is the clearest possible framing of what changed.
+- *Docstring on `entropyRegion_n` is updated to describe the new behavior.* The phrasing "a `Type u` realization is literally a member of the set" is the clearest possible framing of what changed.
 
 **Issues to address: none blocking.**
 


### PR DESCRIPTION
## Description

- Generalize `entropyRegion_n` and `almostEntropicRegion_n` to the ambient universe `u`, and thread that same universe through the Theorem 4 exact-closure lemmas and public theorems.
- Refresh `ZhangYeungTest` coverage so a `Type u` entropy function is literally a member of `entropyRegion_n.{u} n`, and pin the updated `theorem4.{u}` / `theorem4_ge_four.{u}` signatures.
- Archive the universe-polymorphism follow-up plan, update the related theorem-plan documentation, and include the branch review doc in a lint-clean form.

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make check`)
- [x] I have updated the documentation if needed